### PR TITLE
Accommodate variant data in ezstream logs

### DIFF
--- a/lib/rwj_reporter.rb
+++ b/lib/rwj_reporter.rb
@@ -17,13 +17,14 @@ class RwjReporter
   #  <body>1,1,21,unlimited,-1,, - Show Number 062<br />1,1,21,unlimited,-1,, - Show Number 196a<br /></body>
   #
   # where the <body> contains "lines" that end with show numbers (lines are separated by <br> tags, not necessarily line breaks).
-  # the show number should be the last thing on each line.  a show "number" might contain alpha chars, and is not strictly numeric.
+  # the show number should be the last thing on each line.  a show "number" might contain alpha chars, is not strictly numeric,
+  # and can be labeled both "Show Number" or simply "show".
   #
   # returns an array of show numbers from such a text file by finding matches for a simple regex in the text.
   # so, in the above example, the result would be ["062", "196a"]
   def self.get_show_numbers_from_log_file(fname)
     log_file_content = open(fname).read
-    log_file_content.scan(/Show Number (\w+)</).flatten
+    log_file_content.scan(/Show Number (\w+)<|show(\w+)</).flatten.compact
   end
 
   def self.get_filenames_for_date_range(log_file_dir, start_date_str, end_date_str)

--- a/lib/track_merged_csv_printer.rb
+++ b/lib/track_merged_csv_printer.rb
@@ -38,8 +38,9 @@ class TrackMergedCSVPrinter
     # This returns a modified hash that normalizes the shownumber key.
     def normalized_show_counts
       @normalized_show_counts ||= show_counts.map do |shownum, count|
+        next if shownum.nil?
         [normalized_show_number(shownum), count]
-      end.to_h
+      end.compact.to_h
     end
 
     def create_output_directory

--- a/spec/fixtures/streamguys.160303- 601.log
+++ b/spec/fixtures/streamguys.160303- 601.log
@@ -5,5 +5,5 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>StreamGuys Icecast Server</title>
   </head>
-  <body>1,1,11,unlimited,-1,, - Show Number 156a<br />1,1,11,unlimited,-1,, - Show Number 046b<br /></body>
+  <body>1,1,11,unlimited,-1,, - Show Number 156a<br />1,1,11,unlimited,-1,, - show046b<br /></body>
 </html>

--- a/spec/fixtures/streamguys.160303-1101.log
+++ b/spec/fixtures/streamguys.160303-1101.log
@@ -5,5 +5,5 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>StreamGuys Icecast Server</title>
   </head>
-  <body>1,1,22,unlimited,-1,, - Show Number 181a<br />1,1,18,unlimited,-1,, - Show Number 101<br /></body>
+  <body>1,1,22,unlimited,-1,, - Show Number 181a<br />1,1,18,unlimited,-1,, - show101<br /></body>
 </html>

--- a/spec/lib/rwj_reporter_spec.rb
+++ b/spec/lib/rwj_reporter_spec.rb
@@ -20,6 +20,11 @@ describe 'RwjReporter' do
       fname = "#{FIXTURE_DIR}/streamguys.160201- 101.log"
       expect(RwjReporter.get_show_numbers_from_log_file(fname)).to eq ['062', '196a']
     end
+
+    it 'handles show numbers formatted as "show123a" as well as "Show Number 123a"' do
+      fname = "#{FIXTURE_DIR}/streamguys.160303-1101.log"
+      expect(RwjReporter.get_show_numbers_from_log_file(fname)).to eq ['181a', '101']
+    end
   end
 
   context '.get_filenames_for_date_range' do

--- a/spec/lib/track_merged_csv_printer_spec.rb
+++ b/spec/lib/track_merged_csv_printer_spec.rb
@@ -102,4 +102,11 @@ describe TrackMergedCSVPrinter do
       expect(subject.send(:normalized_show_number, 'abc414def')).to eq '414'
     end
   end
+
+  describe '#normalized_show_counts' do
+    let(:show_counts) { { nil => 1, '123' => 4 } }
+    it 'excludes show counts without a show number' do
+      expect(subject.send(:normalized_show_counts)).to eq('123' => 4)
+    end
+  end
 end


### PR DESCRIPTION
Show numbers can be labeled as `Show Number` and simply `show`.

Also, empty `<body>` tags can be passed as well as single channel data, so the CSV printer will now exclude `nil` show numbers.
